### PR TITLE
Make a release of version 0.1.2.

### DIFF
--- a/pyaml_cs_oa/__init__.py
+++ b/pyaml_cs_oa/__init__.py
@@ -3,7 +3,7 @@ import contextlib
 from typing import Awaitable, Any
 import atexit
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 # One persistent event loop
 _loop = None


### PR DESCRIPTION
We need to make a new release because the version on pypi still have the dependency of `pyaml` and not `accelerator-middle-layer` causing namespace conflicts and the wrong package being imported when doing `import pyaml`.