### PR TITLE
Removed is_array_flag

### DIFF
--- a/pyaml_cs_oa/controlsystem.py
+++ b/pyaml_cs_oa/controlsystem.py
@@ -73,11 +73,11 @@ class OphydAsyncControlSystem(ControlSystem):
 
     def attach(self, devs: list[OASignal | None]) -> list[OASignal | None]:
         # Deprecated function
-        return self._attach([d._cfg if d is not None else None for d in devs], False)
+        return self._attach([d._cfg if d is not None else None for d in devs])
 
     def attach_array(self, devs: list[OASignal | None]) -> list[OASignal | None]:
         # Deprecated function
-        return self._attach([d._cfg if d is not None else None for d in devs], True)
+        return self._attach([d._cfg if d is not None else None for d in devs])
 
     def get_device(self, ref: str | BaseModel | None) -> DeviceAccess | None:
         if ref is None:
@@ -93,17 +93,17 @@ class OphydAsyncControlSystem(ControlSystem):
                 raise PyAMLException(f"Control system '{self.name()}' catalog cannot resolve key '{ref}'") from exc
 
         if isinstance(ref, EpicsConfigR):
-            return self._attach([ref], ref.index is not None)[0]
+            return self._attach([ref])[0]
         if isinstance(ref, EpicsConfigW):
-            return self._attach([ref], ref.index is not None)[0]
+            return self._attach([ref])[0]
         if isinstance(ref, EpicsConfigRW):
-            return self._attach([ref], ref.index is not None)[0]
+            return self._attach([ref])[0]
         if isinstance(ref, TangoConfigAtt):
-            return self._attach([ref], ref.index is not None)[0]
+            return self._attach([ref])[0]
 
         raise PyAMLException(f"Control system '{self.name()}' cannot build a device from {type(ref).__name__}")
 
-    def _attach(self, configs: list[ControlSysConfig | None], is_array: bool) -> list[OASignal | None]:
+    def _attach(self, configs: list[ControlSysConfig | None]) -> list[OASignal | None]:
         # Concatenate the prefix
         newDevs = []
         for sig_cfg in configs:
@@ -135,7 +135,7 @@ class OphydAsyncControlSystem(ControlSystem):
 
                 if key not in self._devices:
                     n_conf = dict(sig_cfg) | config
-                    nr = sig_cls(sig_cfg_cls(**n_conf), is_array)
+                    nr = sig_cls(sig_cfg_cls(**n_conf))
                     nr.build()
                     self._devices[key] = nr
 

--- a/pyaml_cs_oa/epics.py
+++ b/pyaml_cs_oa/epics.py
@@ -57,7 +57,7 @@ def create_signal_rw(read_pv: str, write_pv: str, timeout: float) -> SignalR:
     return ALL_RW[key]
 
 
-def get_SP_RB(cfg: ControlSysConfig, is_array: bool) -> tuple[Setpoint | None, Readback | None]:
+def get_SP_RB(cfg: ControlSysConfig) -> tuple[Setpoint | None, Readback | None]:
     setpoint: Setpoint | None = None
     readback: Readback | None = None
 

--- a/pyaml_cs_oa/epicsR.py
+++ b/pyaml_cs_oa/epicsR.py
@@ -8,8 +8,8 @@ class ConfigModel(EpicsConfigR): ...
 
 
 class EpicsR(FloatSignalContainer):
-    def __init__(self, cfg: ConfigModel, is_array: bool = False):
-        super().__init__(cfg, is_array)
+    def __init__(self, cfg: ConfigModel):
+        super().__init__(cfg)
 
     def get_cs(self) -> str:
         return "epics"

--- a/pyaml_cs_oa/epicsRW.py
+++ b/pyaml_cs_oa/epicsRW.py
@@ -8,8 +8,8 @@ class ConfigModel(EpicsConfigRW): ...
 
 
 class EpicsRW(FloatSignalContainer):
-    def __init__(self, cfg: ConfigModel, is_array: bool = False):
-        super().__init__(cfg, is_array)
+    def __init__(self, cfg: ConfigModel):
+        super().__init__(cfg)
 
     def get_cs(self) -> str:
         return "epics"

--- a/pyaml_cs_oa/epicsW.py
+++ b/pyaml_cs_oa/epicsW.py
@@ -8,8 +8,8 @@ class ConfigModel(EpicsConfigW): ...
 
 
 class EpicsW(FloatSignalContainer):
-    def __init__(self, cfg: ConfigModel, is_array: bool = False):
-        super().__init__(cfg, is_array)
+    def __init__(self, cfg: ConfigModel):
+        super().__init__(cfg)
 
     def get_cs(self) -> str:
         return "epics"

--- a/pyaml_cs_oa/float_signal.py
+++ b/pyaml_cs_oa/float_signal.py
@@ -9,8 +9,8 @@ class FloatSignalContainer(OASignal):
     Class that implements a PyAML Float/FloatArray Signal using ophyd_async Signals.
     """
 
-    def __init__(self, cfg: ControlSysConfig, is_array: bool):
-        super().__init__(cfg, is_array)
+    def __init__(self, cfg: ControlSysConfig):
+        super().__init__(cfg)
 
     def _indexed_float(self, value) -> float:
         if self._cfg.index is None:

--- a/pyaml_cs_oa/signal.py
+++ b/pyaml_cs_oa/signal.py
@@ -14,10 +14,8 @@ class OASignal(DeviceAccess):
     Class that implements a PyAML Signal using ophyd_async Signals.
     """
 
-    def __init__(self, cfg: ControlSysConfig, is_array: bool = False):
+    def __init__(self, cfg: ControlSysConfig):
         self._cfg = cfg
-        # is_array is forced True whenever any index is specified.
-        self.is_array = is_array or cfg.index is not None
 
     def build(self):
         self._readable: bool = isinstance(self._cfg, (EpicsConfigR, TangoConfigAtt))
@@ -31,7 +29,7 @@ class OASignal(DeviceAccess):
         else:
             raise ValueError(f"Unsupported cs_name: {cs_name}")
 
-        self.SP, self.RB = get_SP_RB(self._cfg, self.is_array)
+        self.SP, self.RB = get_SP_RB(self._cfg)
 
         if self.SP:
             self.SP.__peer__ = self

--- a/pyaml_cs_oa/tango.py
+++ b/pyaml_cs_oa/tango.py
@@ -10,14 +10,14 @@ from .types import (
 )
 
 
-def get_SP_RB(cfg: ControlSysConfig, is_array: bool) -> tuple[Setpoint | None, Readback | None]:
+def get_SP_RB(cfg: ControlSysConfig) -> tuple[Setpoint | None, Readback | None]:
     setpoint: Setpoint | None = None
     readback: Readback | None = None
 
     assert isinstance(cfg, TangoConfigAtt)
 
     rw_sig = tango_signal_rw(
-        datatype=float if not is_array else Array1D[numpy.float64],
+        datatype=None,
         read_trl=cfg.attribute,
         write_trl=cfg.attribute,
         timeout=cfg.timeout_ms,

--- a/pyaml_cs_oa/tangoAtt.py
+++ b/pyaml_cs_oa/tangoAtt.py
@@ -8,8 +8,8 @@ class ConfigModel(TangoConfigAtt): ...
 
 
 class TangoAtt(FloatSignalContainer):
-    def __init__(self, cfg: ConfigModel, is_array: bool = False):
-        super().__init__(cfg, is_array)
+    def __init__(self, cfg: ConfigModel):
+        super().__init__(cfg)
 
     def get_cs(self) -> str:
         return "tango"

--- a/tests/test_bpm_orbit.py
+++ b/tests/test_bpm_orbit.py
@@ -74,7 +74,7 @@ class IndexedVectorSignal(FloatSignalContainer):
     """FloatSignalContainer fake resolving one indexed value from a shared vector."""
 
     def __init__(self, config: IndexedVectorSignalConfig) -> None:
-        super().__init__(config, is_array=True)
+        super().__init__(config)
         self._readable = True
         self._writable = False
         self.RB = _VectorReadSide(config.source)

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -30,7 +30,7 @@ def test_epics_read_only_factory_builds_readback(
     spy = SignalFactorySpy("epics-r")
     monkeypatch.setattr(epics, "epics_signal_r", spy)
 
-    setpoint, readback = epics.get_SP_RB(EpicsConfigR(read_pvname="PV:RB"), False)
+    setpoint, readback = epics.get_SP_RB(EpicsConfigR(read_pvname="PV:RB"))
 
     assert setpoint is None
     assert isinstance(readback, OAReadback)
@@ -45,7 +45,7 @@ def test_epics_write_only_factory_builds_setpoint(
     spy = SignalFactorySpy("epics-w")
     monkeypatch.setattr(epics, "epics_signal_w", spy)
 
-    setpoint, readback = epics.get_SP_RB(EpicsConfigW(write_pvname="PV:SP"), False)
+    setpoint, readback = epics.get_SP_RB(EpicsConfigW(write_pvname="PV:SP"))
 
     assert isinstance(setpoint, OASetpoint)
     assert readback is None
@@ -59,10 +59,7 @@ def test_epics_read_write_factory_reuses_single_rw_signal(
     spy = SignalFactorySpy("epics-rw")
     monkeypatch.setattr(epics, "epics_signal_rw", spy)
 
-    setpoint, readback = epics.get_SP_RB(
-        EpicsConfigRW(read_pvname="PV:RB", write_pvname="PV:SP"),
-        False,
-    )
+    setpoint, readback = epics.get_SP_RB(EpicsConfigRW(read_pvname="PV:RB", write_pvname="PV:SP"))
 
     assert isinstance(setpoint, OASetpoint)
     assert isinstance(readback, OAReadback)
@@ -77,10 +74,7 @@ def test_tango_read_write_factory_reuses_single_rw_signal(
     spy = SignalFactorySpy("tango-rw")
     monkeypatch.setattr(tango, "tango_signal_rw", spy)
 
-    setpoint, readback = tango.get_SP_RB(
-        TangoConfigAtt(attribute="sys/tg_test/1/value"),
-        False,
-    )
+    setpoint, readback = tango.get_SP_RB(TangoConfigAtt(attribute="sys/tg_test/1/value"))
 
     assert isinstance(setpoint, OASetpoint)
     assert isinstance(readback, OAReadback)

--- a/tests/test_scalar_aggregator.py
+++ b/tests/test_scalar_aggregator.py
@@ -12,7 +12,7 @@ class FakeScalarSignal(FloatSignalContainer):
     """FloatSignalContainer test double with fake SP/RB sides."""
 
     def __init__(self, value: float, writable: bool = True) -> None:
-        super().__init__(EpicsConfigR(read_pvname="PV:RB"), is_array=False)
+        super().__init__(EpicsConfigR(read_pvname="PV:RB"))
         self._writable = writable
         self.SP = _FakeSide(value, signal_key=object())
         self.RB = _FakeSide(value, signal_key=object())

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -20,10 +20,9 @@ def test_epics_signal_build_sets_peer_on_built_sides(
     setpoint = BuiltSide()
     readback = BuiltSide()
 
-    def fake_get_sp_rb(cfg, is_array):
+    def fake_get_sp_rb(cfg):
         assert cfg.read_pvname == "PV:RB"
         assert cfg.write_pvname == "PV:SP"
-        assert is_array is False
         return setpoint, readback
 
     monkeypatch.setattr("pyaml_cs_oa.epics.get_SP_RB", fake_get_sp_rb)
@@ -40,14 +39,13 @@ def test_epics_signal_build_sets_peer_on_built_sides(
 def test_tango_signal_build_uses_tango_factory(monkeypatch: pytest.MonkeyPatch) -> None:
     readback = BuiltSide()
 
-    def fake_get_sp_rb(cfg, is_array):
+    def fake_get_sp_rb(cfg):
         assert cfg.attribute == "sys/tg_test/1/value"
-        assert is_array is True
         return None, readback
 
     monkeypatch.setattr("pyaml_cs_oa.tango.get_SP_RB", fake_get_sp_rb)
 
-    signal = TangoAtt(TangoAttConfig(attribute="sys/tg_test/1/value"), is_array=True)
+    signal = TangoAtt(TangoAttConfig(attribute="sys/tg_test/1/value"))
     signal.build()
 
     assert signal.SP is None


### PR DESCRIPTION
This PR remove the is_array flag.
It is OK for EPICS (tested on BESSY2 VA) however for Tango it requires [this](https://github.com/bluesky/ophyd-async/issues/1228#issuecomment-4621616207)